### PR TITLE
Fix event->getServer() deprecation for php ext-mongodb 2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "require": {
     "php": "^7.2 || ^8.0",
-    "ext-mongodb": "*",
+    "ext-mongodb": "^1.20.0 || ^2.0.0",
     "code-tool/jaeger-client-php": "^3"
   },
   "autoload": {

--- a/src/JaegerMongoDbQueryTimeCollector.php
+++ b/src/JaegerMongoDbQueryTimeCollector.php
@@ -41,8 +41,6 @@ class JaegerMongoDbQueryTimeCollector implements CommandSubscriber
 
     public function commandStarted(CommandStartedEvent $event): void
     {
-        /** @var MongoDB\Driver\Server $server */
-        $server = $event->getServer();
         $this->requestIdToSpan[$event->getRequestId()] = $this->tracer->start(
             sprintf('mongodb.%s', $event->getCommandName()),
             [
@@ -51,8 +49,8 @@ class JaegerMongoDbQueryTimeCollector implements CommandSubscriber
                 new DbType('mongo'),
                 new DbInstanceTag($event->getDatabaseName()),
                 new DbStatementTag($this->convertor->convert($event->getCommand())),
-                new PeerHostnameTag($server->getHost()),
-                new PeerPortTag($server->getPort()),
+                new PeerHostnameTag($event->getHost()),
+                new PeerPortTag($event->getPort()),
             ]
         );
     }


### PR DESCRIPTION
https://www.php.net/manual/en/mongodb-driver-monitoring-commandstartedevent.getserver.php
**getServer** method is removed in 2+. **getHost** and **getPort** are available withing the event object from mongo extension version 1.20.0